### PR TITLE
support AMD

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,15 @@
 ;(function (root, factory) {
 
-  factory(ractive(), hammer());
-
-  function ractive() {
-    return root.Ractive || require('ractive');
+  if (typeof define === 'function' && define.amd) {
+    define(['ractive', 'hammerjs'], factory);
   }
-  function hammer() {
-    return root.Hammer || require('hammerjs');
+
+  else if (typeof module !== 'undefined') {
+    factory(require('ractive'), require('hammerjs'));
+  }
+
+  else {
+    factory(root.Ractive, root.Hammer);
   }
 
 }(this, function (Ractive, Hammer) {


### PR DESCRIPTION
Hi Rico

My colleague used ractive-touch on a project the other day ([this article](http://www.theguardian.com/world/ng-interactive/2014/aug/20/-sp-cemetery-for-our-people-guatemalan-consul-texas-migrant-crisis), scroll down to 'The things they carried') - it worked beautifully and saved us a ton of time, so thank you.

We had to modify it to work with our AMD-based stack, so I thought I'd submit this PR - getting modules with external dependencies to work across browserify/AMD/normal browser is a massive pain but this pattern seems fairly reliable.
